### PR TITLE
fix: fix timeout settings in sf-graph-client [SF-210]

### DIFF
--- a/packages/sf-graph-client/test/hooks/lending-market.test.ts
+++ b/packages/sf-graph-client/test/hooks/lending-market.test.ts
@@ -42,12 +42,12 @@ describe('Lending market test', () => {
                 useLendingMarkets({ ccy }, client)
             );
 
-            await waitForNextUpdate();
+            await waitForNextUpdate({ timeout: 5000 });
 
             expect(result.current.error).to.be.undefined;
 
             const lendingMarkets = result.current.data?.lendingMarkets;
-            expect(lendingMarkets?.length).to.be.equal(4);
+            expect(lendingMarkets?.length).to.be.equal(8);
 
             market = lendingMarkets?.[0].id as string;
 
@@ -62,7 +62,7 @@ describe('Lending market test', () => {
             const { result, waitForNextUpdate } = renderHook(() =>
                 useLendingMarketInfo({ lendingMarket: '0x02' }, client)
             );
-            await waitForNextUpdate();
+            await waitForNextUpdate({ timeout: 5000 });
 
             expect(result.current.error).to.be.undefined;
             expect(result.current.data).to.be.undefined;
@@ -73,7 +73,7 @@ describe('Lending market test', () => {
                 useLendingMarketInfo({ lendingMarket: market }, client)
             );
 
-            await waitForNextUpdate();
+            await waitForNextUpdate({ timeout: 5000 });
 
             expect(result.current.error).to.be.undefined;
 
@@ -94,7 +94,7 @@ describe('Lending market test', () => {
                 )
             );
 
-            await waitForNextUpdate();
+            await waitForNextUpdate({ timeout: 5000 });
 
             expect(result.current.error).to.be.undefined;
 
@@ -111,7 +111,7 @@ describe('Lending market test', () => {
                 )
             );
 
-            await waitForNextUpdate();
+            await waitForNextUpdate({ timeout: 5000 });
 
             expect(result.current.error).to.be.undefined;
 
@@ -134,7 +134,7 @@ describe('Lending market test', () => {
                 )
             );
 
-            await waitForNextUpdate();
+            await waitForNextUpdate({ timeout: 5000 });
 
             expect(result.current.error).to.be.undefined;
 
@@ -151,7 +151,7 @@ describe('Lending market test', () => {
                 )
             );
 
-            // await waitForNextUpdate();
+            // await waitForNextUpdate({ timeout: 5000 });
             await waitForNextUpdate({ timeout: 5000 });
 
             expect(result.current.error).to.be.undefined;
@@ -170,7 +170,7 @@ describe('Lending market test', () => {
                 useLendingTradingHistory({ lendingMarket: '0x01' }, client)
             );
 
-            await waitForNextUpdate();
+            await waitForNextUpdate({ timeout: 5000 });
 
             expect(result.current.error).to.be.undefined;
             expect(result.current.data).to.be.undefined;
@@ -181,7 +181,7 @@ describe('Lending market test', () => {
                 useLendingTradingHistory({ lendingMarket: market }, client)
             );
 
-            await waitForNextUpdate();
+            await waitForNextUpdate({ timeout: 5000 });
 
             expect(result.current.error).to.be.undefined;
 

--- a/packages/sf-graph-client/test/hooks/loans.test.ts
+++ b/packages/sf-graph-client/test/hooks/loans.test.ts
@@ -25,7 +25,7 @@ describe('Loans test', () => {
                 useBorrowingDeals({ account }, client)
             );
 
-            await waitForNextUpdate();
+            await waitForNextUpdate({ timeout: 5000 });
             expect(result.current.error).to.be.undefined;
 
             if (result.current.data?.loans !== undefined) {
@@ -59,7 +59,7 @@ describe('Loans test', () => {
                 useLoanInfo({ id }, client)
             );
 
-            await waitForNextUpdate();
+            await waitForNextUpdate({ timeout: 5000 });
 
             expect(result.current.error).to.be.undefined;
             expect(result.current.data?.loan).to.be.undefined;

--- a/packages/sf-graph-client/test/hooks/user.test.ts
+++ b/packages/sf-graph-client/test/hooks/user.test.ts
@@ -24,7 +24,7 @@ describe('User test', () => {
                 useOpenOrders({ account, market }, client)
             );
 
-            await waitForNextUpdate();
+            await waitForNextUpdate({ timeout: 5000 });
 
             expect(result.current.error).to.be.undefined;
 
@@ -43,7 +43,7 @@ describe('User test', () => {
                 useUsersTradingHistoryQuery({ account, market }, client)
             );
 
-            await waitForNextUpdate();
+            await waitForNextUpdate({ timeout: 5000 });
 
             expect(result.current.error).to.be.undefined;
 


### PR DESCRIPTION
- Fix the timeout option in the test code of `sf-graph-client`.

It seems the graph takes a little time to return the data when the test codes access the graph again and again.
Generally, at the frontend there is a cache layer on the GraphQL but in the test code there is not.
Because of that, the graph is accessed from the same IP again and again.
In those case, it seems the graph returns a response slowly.