### PR TITLE
build: add log for deploy graph [SF-194]

### DIFF
--- a/.github/workflows/deploy-graph.yml
+++ b/.github/workflows/deploy-graph.yml
@@ -1,6 +1,7 @@
 name: Deploy Graph
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/packages/secured-finance-subgraph/package.json
+++ b/packages/secured-finance-subgraph/package.json
@@ -12,9 +12,9 @@
     "test": "graph test",
     "coverage": "graph test -- -c",
     "auth": "graph auth --product hosted-service",
-    "deploy:local": "graph deploy secured-finance/sf-protocol-local ./subgraph.localhost.yaml --product hosted-service --output-dir ./build/localhost --ipfs http://localhost:5001 --node http://127.0.0.1:8020",
-    "deploy:dev": "graph deploy secured-finance/sf-protocol-dev ./subgraph.development.yaml --product hosted-service --output-dir ./build/development",
-    "deploy:stg": "graph deploy secured-finance/sf-protocol-stg ./subgraph.staging.yaml --product hosted-service --output-dir ./build/staging",
+    "deploy:local": "cat ./subgraph.localhost.yaml && graph deploy secured-finance/sf-protocol-local ./subgraph.localhost.yaml --product hosted-service --output-dir ./build/localhost --ipfs http://localhost:5001 --node http://127.0.0.1:8020",
+    "deploy:dev": "cat ./subgraph.development.yaml && graph deploy secured-finance/sf-protocol-dev ./subgraph.development.yaml --product hosted-service --output-dir ./build/development",
+    "deploy:stg": "cat ./subgraph.staging.yaml && graph deploy secured-finance/sf-protocol-stg ./subgraph.staging.yaml --product hosted-service --output-dir ./build/staging",
     "prepublish": "npm run codegen"
   },
   "devDependencies": {

--- a/packages/secured-finance-subgraph/scripts/generate.ts
+++ b/packages/secured-finance-subgraph/scripts/generate.ts
@@ -24,10 +24,7 @@ class Main {
             );
 
             const proxyAddress = deployment.address;
-            const blockNumber = deployment.receipt.blockNumber;
-
             dataSource.source.address = proxyAddress;
-            dataSource.source.startBlock = blockNumber;
         }
 
         const newYamlText = dump(data);


### PR DESCRIPTION
- Removed block in graph definition as it is an optional parameter
- Allow the deploy graph to be run manually (but needs to be merged first I think)
- Add logs of the generated config