### PR TITLE
fix: update the deployment setting of subgraph [SF-180]

### DIFF
--- a/.github/workflows/deploy-graph.yml
+++ b/.github/workflows/deploy-graph.yml
@@ -27,7 +27,9 @@ jobs:
           base: ${{ steps.extract_branch.outputs.branch }}
           filters: |
             subgraph:
-              - 'packages/secured-finance-subgraph/**'
+              - 'packages/secured-finance-subgraph/src/**'
+              - 'packages/secured-finance-subgraph/schema.graphql'
+              - 'packages/secured-finance-subgraph/subgraph.yaml'
   deploy:
     name: Deploy Graph
     runs-on: ubuntu-latest

--- a/packages/secured-finance-subgraph/deployment.json
+++ b/packages/secured-finance-subgraph/deployment.json
@@ -2,7 +2,7 @@
   "development": {
     "isMajorUpdate": false,
     "isMinorUpdate": false,
-    "version": "0.0.8"
+    "version": "0.0.9"
   },
   "staging": {
     "isMajorUpdate": false,

--- a/packages/sf-graph-client/src/graphclients/development/.graphclientrc.yml
+++ b/packages/sf-graph-client/src/graphclients/development/.graphclientrc.yml
@@ -2,7 +2,7 @@ sources:
   - name: sf-protocol
     handler:
       graphql:
-        endpoint: https://api.studio.thegraph.com/query/30564/sf-protocol-dev/0.0.8
+        endpoint: https://api.studio.thegraph.com/query/30564/sf-protocol-dev/0.0.9
     transforms:
       - blockTracking:
           validateSchema: true


### PR DESCRIPTION
The latest workflow of the subgraph deployment failed because the previous version is archived when a new version is updated.
This PR is a workaround to pass the workflow at this point.