### PR TITLE
fix: add network for template [SF-246]

### DIFF
--- a/packages/secured-finance-subgraph/scripts/generate.ts
+++ b/packages/secured-finance-subgraph/scripts/generate.ts
@@ -40,6 +40,10 @@ class Main {
             dataSource.network = this.network;
         }
 
+        for (const template of data.templates) {
+            template.network = this.network;
+        }
+
         const newYamlText = dump(data);
 
         writeFileSync(


### PR DESCRIPTION
The deployment of the graph is failing because there is not network in the template.
I added it in the generation phase