### PR TITLE
fix: queries updated to bring expired or cancelled orders [SF-520]

### DIFF
--- a/packages/sf-graph-client/src/graphclients/development/.graphclientrc.yml
+++ b/packages/sf-graph-client/src/graphclients/development/.graphclientrc.yml
@@ -2,7 +2,7 @@ sources:
   - name: sf-protocol
     handler:
       graphql:
-        endpoint: https://api.studio.thegraph.com/query/30564/sf-protocol-dev/0.1.3
+        endpoint: https://api.studio.thegraph.com/query/30564/sf-protocol-dev/0.1.4
     transforms:
       - blockTracking:
           validateSchema: true

--- a/packages/sf-graph-client/src/queries/development/lending-market.ts
+++ b/packages/sf-graph-client/src/queries/development/lending-market.ts
@@ -39,7 +39,6 @@ export const USER_HISTORY = gql`
         user(id: $address) {
             id
             transactions(orderBy: createdAt, orderDirection: desc) {
-                id
                 currency
                 maturity
                 side
@@ -49,10 +48,12 @@ export const USER_HISTORY = gql`
                 averagePrice
                 createdAt
             }
-            orders(orderBy: createdAt, orderDirection: desc) {
-                id
+            orders(
+                orderBy: createdAt
+                orderDirection: desc
+                where: { status_in: [Expired, Cancelled] }
+            ) {
                 orderId
-                originalOrderId
                 currency
                 side
                 maturity
@@ -60,8 +61,6 @@ export const USER_HISTORY = gql`
                 amount
                 status
                 createdAt
-                blockNumber
-                txHash
             }
         }
     }

--- a/packages/sf-graph-client/src/queries/staging/lending-market.ts
+++ b/packages/sf-graph-client/src/queries/staging/lending-market.ts
@@ -39,7 +39,6 @@ export const USER_HISTORY = gql`
         user(id: $address) {
             id
             transactions(orderBy: createdAt, orderDirection: desc) {
-                id
                 currency
                 maturity
                 side
@@ -50,9 +49,7 @@ export const USER_HISTORY = gql`
                 createdAt
             }
             orders(orderBy: createdAt, orderDirection: desc) {
-                id
                 orderId
-                originalOrderId
                 currency
                 side
                 maturity
@@ -60,8 +57,6 @@ export const USER_HISTORY = gql`
                 amount
                 status
                 createdAt
-                blockNumber
-                txHash
             }
         }
     }


### PR DESCRIPTION
UserHistory query update to get Cancelled and Expired orders only
Also removed unused fields 