### PR TITLE
chore: change suported networks to sepolia [SF-506]

### DIFF
--- a/packages/sf-client/package-lock.json
+++ b/packages/sf-client/package-lock.json
@@ -6,11 +6,11 @@
   "packages": {
     "": {
       "name": "@secured-finance/sf-client",
-      "version": "0.2.0-beta.67",
+      "version": "0.2.0-beta.69",
       "license": "MIT",
       "dependencies": {
         "@secured-finance/sf-core": "^0.2.0-beta.40",
-        "@secured-finance/smart-contracts": "0.0.7-beta.2",
+        "@secured-finance/smart-contracts": "0.0.7",
         "ethers": "^5.7.1",
         "gas-price-oracle": "^0.4.4"
       },
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@secured-finance/smart-contracts": {
-      "version": "0.0.7-beta.2",
-      "resolved": "https://npm.pkg.github.com/download/@Secured-Finance/smart-contracts/0.0.7-beta.2/9e29ce8996af4016bbe8ff0be3d9830dbd71edcc",
-      "integrity": "sha512-ZWCaakXsU3HSYQQMlF9SGl/9R0tP+/E+Lcz1KLuulJf7j0JKwETnyPClNZ+tY7O9yhmNRLI4xg0CJu5N5hI3PA==",
+      "version": "0.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@Secured-Finance/smart-contracts/0.0.7/7f697e39c61765edace1fc4ce70f8f8e8d5a8c8f",
+      "integrity": "sha512-xbg6gIyKwLBbBRXuv2+fny67iaj4kgpF7j1t7FKkLx2hIoSBCEOgR2oqQog2STClINKXOuSU4+6xkIcHcFamtQ==",
       "license": "ISC",
       "dependencies": {
         "@chainlink/contracts": "^0.4.0",
@@ -6658,9 +6658,9 @@
       "integrity": "sha512-+wJBGJPVz3iNOcIMabCbkmoeniFm2ovQxujoqbbYns4cRdta3UkW3HTDnf8V8U3WovuE4o2CDAm++0arqxyb4g=="
     },
     "@secured-finance/smart-contracts": {
-      "version": "0.0.7-beta.2",
-      "resolved": "https://npm.pkg.github.com/download/@Secured-Finance/smart-contracts/0.0.7-beta.2/9e29ce8996af4016bbe8ff0be3d9830dbd71edcc",
-      "integrity": "sha512-ZWCaakXsU3HSYQQMlF9SGl/9R0tP+/E+Lcz1KLuulJf7j0JKwETnyPClNZ+tY7O9yhmNRLI4xg0CJu5N5hI3PA==",
+      "version": "0.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@Secured-Finance/smart-contracts/0.0.7/7f697e39c61765edace1fc4ce70f8f8e8d5a8c8f",
+      "integrity": "sha512-xbg6gIyKwLBbBRXuv2+fny67iaj4kgpF7j1t7FKkLx2hIoSBCEOgR2oqQog2STClINKXOuSU4+6xkIcHcFamtQ==",
       "requires": {
         "@chainlink/contracts": "^0.4.0",
         "@openzeppelin/contracts": "^4.7.3",

--- a/packages/sf-client/package.json
+++ b/packages/sf-client/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@secured-finance/sf-core": "^0.2.0-beta.40",
-    "@secured-finance/smart-contracts": "0.0.7-beta.2",
+    "@secured-finance/smart-contracts": "0.0.7",
     "ethers": "^5.7.1",
     "gas-price-oracle": "^0.4.4"
   },

--- a/packages/sf-client/src/contracts/base-contract.ts
+++ b/packages/sf-client/src/contracts/base-contract.ts
@@ -11,13 +11,13 @@ type NetworkMap = Record<NetworkName, string>;
 
 const DEPLOYMENT_PATH_MAP: Record<Environment, Partial<NetworkMap>> = {
     development: {
-        goerli: 'development',
+        sepolia: 'development',
     },
     staging: {
-        goerli: 'staging',
+        sepolia: 'staging',
     },
     production: {
-        goerli: 'goerli',
+        sepolia: 'sepolia',
         mainnet: 'production',
     },
 };

--- a/packages/sf-client/src/secured-finance-client.test.ts
+++ b/packages/sf-client/src/secured-finance-client.test.ts
@@ -21,7 +21,7 @@ describe('Secured Finance Client', () => {
 
     it('should be able to init the client', async () => {
         const client = new SecuredFinanceClient();
-        const provider = getProvider('goerli');
+        const provider = getProvider('sepolia');
         await client.init(provider, await provider.getNetwork());
         expect(client).toBeTruthy();
     });
@@ -35,7 +35,7 @@ describe('config', () => {
 
     it('should return the config if the client is initialized', async () => {
         const client = new SecuredFinanceClient();
-        const provider = getProvider('goerli');
+        const provider = getProvider('sepolia');
         await client.init(provider, await provider.getNetwork());
         expect(client.config).toBeTruthy();
     });
@@ -51,7 +51,7 @@ describe('depositCollateral method', () => {
 
     it.skip('should call the depositCollateral contract in a payable way for ETH', async () => {
         const client = new SecuredFinanceClient();
-        const provider = getProvider('goerli');
+        const provider = getProvider('sepolia');
         const network = await provider.getNetwork();
         await client.init(provider, network);
 
@@ -68,7 +68,7 @@ describe('depositCollateral method', () => {
 
     it.skip('should call the depositCollateral contract in a non payable way for ERC20 token', async () => {
         const client = new SecuredFinanceClient();
-        const provider = getProvider('goerli');
+        const provider = getProvider('sepolia');
         const network = await provider.getNetwork();
         await client.init(provider, network);
 
@@ -91,7 +91,7 @@ describe('withdrawCollateral method', () => {
 
     it.skip('should call the withdrawCollateral contract', async () => {
         const client = new SecuredFinanceClient();
-        const provider = getProvider('goerli');
+        const provider = getProvider('sepolia');
         const network = await provider.getNetwork();
         await client.init(provider, network);
 

--- a/packages/sf-client/src/secured-finance-client.ts
+++ b/packages/sf-client/src/secured-finance-client.ts
@@ -485,9 +485,9 @@ export class SecuredFinanceClient extends ContractsInstance {
         }, {} as Record<string, BigNumber>);
     }
 
-    async unwindOrder(currency: Currency, maturity: number) {
+    async unwindPosition(currency: Currency, maturity: number) {
         assertNonNullish(this.lendingMarketController);
-        return this.lendingMarketController.contract.unwindOrder(
+        return this.lendingMarketController.contract.unwindPosition(
             this.convertCurrencyToBytes32(currency),
             maturity
         );

--- a/packages/sf-client/src/test/client.ts
+++ b/packages/sf-client/src/test/client.ts
@@ -18,14 +18,14 @@ class Filecoin extends Token {
 
 const client = new SecuredFinanceClient();
 const provider = new providers.AlchemyProvider(
-    'goerli',
+    'sepolia',
     process.env.ALCHEMY_API_KEY
 );
 
 client
     .init(provider, {
-        chainId: 5,
-        name: 'goerli',
+        chainId: 11155111,
+        name: 'sepolia',
     })
     .then(() => {
         client.getLendingMarkets(new Filecoin()).then(markets => {

--- a/packages/sf-client/src/utils/networks.ts
+++ b/packages/sf-client/src/utils/networks.ts
@@ -1,8 +1,8 @@
 export const NETWORKS: { [key: number]: string } = {
     1: 'mainnet',
-    5: 'goerli',
+    11155111: 'sepolia',
     1337: 'localhost',
 };
 
-export const networkNames = ['goerli', 'mainnet'] as const;
+export const networkNames = ['sepolia', 'mainnet'] as const;
 export type NetworkName = (typeof networkNames)[number];

--- a/packages/sf-client/src/utils/providers.test.ts
+++ b/packages/sf-client/src/utils/providers.test.ts
@@ -4,7 +4,7 @@ import { getLocalhostProvider, getProvider } from './providers';
 describe('Check ethers provider', function () {
     let provider: BaseProvider;
     const mainnetNetworkID = 1;
-    const goerliNetworkID = 5;
+    const sepoliaNetworkID = 11155111;
 
     it('Try connect to mainnet ethers provider, check network ID', async () => {
         provider = getProvider('mainnet');
@@ -12,10 +12,10 @@ describe('Check ethers provider', function () {
         expect(networkId).toEqual(mainnetNetworkID);
     });
 
-    it('Try connect to goerli ethers provider, check network ID', async () => {
-        provider = getProvider('goerli');
+    it('Try connect to sepolia ethers provider, check network ID', async () => {
+        provider = getProvider('sepolia');
         const networkId = await (await provider.getNetwork()).chainId;
-        expect(networkId).toEqual(goerliNetworkID);
+        expect(networkId).toEqual(sepoliaNetworkID);
     });
 
     it('Try connect to localhost provider, check connection URL', async () => {

--- a/packages/sf-graph-client/README.md
+++ b/packages/sf-graph-client/README.md
@@ -16,7 +16,7 @@ import { GraphClientProvider } from '@secured-finance/sf-graph-client';
 
 const App = () => {
     return (
-        <GraphClientProvider network="goerli">
+        <GraphClientProvider network="sepolia">
             <YourPage />
         </GraphClientProvider>
     );

--- a/packages/sf-graph-client/src/components/graphApolloClient.ts
+++ b/packages/sf-graph-client/src/components/graphApolloClient.ts
@@ -20,8 +20,8 @@ const getGraphClient = (network = 'none') => {
     switch (process.env.SF_ENV) {
         case 'development':
             sfEnv = 'development';
-            sfNetwork = 'goerli';
-            if (network !== 'goerli') {
+            sfNetwork = 'sepolia';
+            if (network !== 'sepolia') {
                 console.warn(`${network} is not a supported network.`);
             }
             GraphClient = GraphClientDev;
@@ -29,8 +29,8 @@ const getGraphClient = (network = 'none') => {
 
         case 'staging':
             sfEnv = 'staging';
-            sfNetwork = 'goerli';
-            if (network !== 'goerli') {
+            sfNetwork = 'sepolia';
+            if (network !== 'sepolia') {
                 console.warn(`${network} is not a supported network.`);
             }
             GraphClient = GraphClientStg;
@@ -45,8 +45,8 @@ const getGraphClient = (network = 'none') => {
             //
             // if (network === 'mainnet') {
             //     GraphClient = GraphClientMainnet;
-            // } else if(network === 'goerli') {
-            //     GraphClient = GraphClientGoerli;
+            // } else if(network === 'sepolia') {
+            //     GraphClient = GraphClientSepolia;
             // }
             //     :
             break;

--- a/packages/sf-graph-client/src/graphclients/development/.graphclientrc.yml
+++ b/packages/sf-graph-client/src/graphclients/development/.graphclientrc.yml
@@ -2,7 +2,7 @@ sources:
   - name: sf-protocol
     handler:
       graphql:
-        endpoint: https://api.studio.thegraph.com/query/30564/sf-protocol-dev/0.1.4
+        endpoint: https://api.studio.thegraph.com/query/30564/sf-protocol-dev-sepolia/0.0.2
     transforms:
       - blockTracking:
           validateSchema: true

--- a/packages/sf-graph-client/src/graphclients/staging/.graphclientrc.yml
+++ b/packages/sf-graph-client/src/graphclients/staging/.graphclientrc.yml
@@ -2,7 +2,7 @@ sources:
   - name: sf-protocol
     handler:
       graphql:
-        endpoint: https://api.studio.thegraph.com/query/30564/sf-protocol-stg/0.0.5
+        endpoint: https://api.studio.thegraph.com/query/30564/sf-protocol-stg-sepolia/0.0.1
     transforms:
       - blockTracking:
           validateSchema: true


### PR DESCRIPTION
- Update smart contracts and subgraph settings to the latest.
- Change supported networks from Goerli to Sepolia.